### PR TITLE
feat: upgrade label to version 0.5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.5.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name


### PR DESCRIPTION
Goals: 
- to enable  terraform version >= 12

Reference: 
https://github.com/cloudposse/terraform-terraform-label/compare/0.4.0...0.5.0 
no major changes

```
Error: Unsupported Terraform Core version

  on .terraform/modules/payment-notify.default_label/versions.tf line 2, in terraform:
   2:   required_version = "~> 0.12.0"

Module module.payment-notify.module.default_label (from
git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0)
does not support Terraform version 0.13.7. To proceed, either choose another
supported Terraform version or update this version constraint. Version
constraints are normally set for good reason, so updating the constraint may
lead to other errors or unexpected behavior.
```